### PR TITLE
Fix pagination bug in donations route

### DIFF
--- a/routes/donations.js
+++ b/routes/donations.js
@@ -69,8 +69,8 @@ donationsRouter.get('/', async (req, res) => {
         ON relation3.route_id = d.route_id
         ${allDonationsWhereClause}
         ORDER BY status, pickup_date, submitted_date
-        LIMIT $(numDonations)
-        OFFSET $(pageNum)
+        ${numDonations ? `LIMIT $(numDonations)` : ''}
+        ${pageNum ? `OFFSET ($(pageNum) - 1) * $(numDonations)` : ''}
         ;`,
       {
         numDonations: numDonations,


### PR DESCRIPTION
This PR fixes a bug in the paging for the `GET /donations` route.

A prior PR (#52) fixing a SQL injection vulnerability changed the behavior of the `pageNum` query parameter. Previously, the `numDonations` query parameter was used as the page size, and the `pageNum` parameter was used to determine the offset by multiplying it with `numDonations`. That PR changed the behavior to use `pageNum` as the SQL offset directly, leading to incorrect behavior. For example, if you visit `/donations?numDonations=5&pageNum=2`, it gives you entries 2 through 6 in the table, when it should give you entries 5 through 9 (since page 1 should give you entries 0 through 4, that's how paging works).

This PR changes the behavior back to the original so that paging will work as expected again (while maintaining security against SQL injection).